### PR TITLE
Fixed incorrect container name in the example  command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See https://github.com/uglyog/pact-stub-server for the available CLI options.
 ```sh
 # Create a Stub API
 docker pull pactfoundation/pact-stub-server
-docker run -t -p 8080:8080 -v "$(pwd)/pacts/:/app/pacts" pact-foundation/pact-stub-server -p 8080 -d pacts
+docker run -t -p 8080:8080 -v "$(pwd)/pacts/:/app/pacts" pactfoundation/pact-stub-server -p 8080 -d pacts
 
 # Test your stub endpoints
 curl -v $(docker-machine ip $(docker-machine active)):8080/bazbat


### PR DESCRIPTION
The container name in the `docker run` didn't match the one downloaded in the `docker pull` command